### PR TITLE
Update antivirus_configuration.rst

### DIFF
--- a/admin_manual/configuration_server/antivirus_configuration.rst
+++ b/admin_manual/configuration_server/antivirus_configuration.rst
@@ -175,4 +175,4 @@ Disabling background scan task
 
 You can disable background scan with occ to only scan files during upload.
 
-    occ config:app:set files_antivirus av_background_scan --value="off"
+    occ config:app:set files_antivirus av_background_scan --value="yes"


### PR DESCRIPTION
The former command didn`t work.

```
occ config:app:set files_antivirus av_background_scan –-value="off"
```

It caused the error:

```
Too many arguments to "config:app:set" command, expected arguments "app" "name".
``

### ☑️ Resolves

The new command worked without any problems.

```
occ config:app:set files_antivirus av_background_scan --value="yes"
```

The message shows the successful execution of the command:

```
Config value av_background_scan for app files_antivirus set to yes
```

### 🖼️ Screenshots

<!--
Please add a screenshot of your changed or added page(s).
This helps reviewers to quickly see how the resulting
lists, code blocks, headers and links look.
-->
